### PR TITLE
Add optional error message to Action Response

### DIFF
--- a/connector.proto
+++ b/connector.proto
@@ -29,6 +29,7 @@ message ActionResponse {
   };
   Status status = 1;
   map<string,string> outputs = 2;
+  string error_message = 3;
 }
 
 message Trigger {


### PR DESCRIPTION
The Action Response had a status field which could be set to ERROR, but needed another field to be able to include a message for why the error occurred. This PR adds that error message field.

Co-authored-by: Wesley Morlock <wmorlock@mavenlink.com>